### PR TITLE
Add top-level scripts for laser-mace-testing Vercel deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,10 @@
     "lint": "npm run lint --workspaces",
     "fetch:laser-mace": "./scripts/sync-package.sh laser-mace packages/laser-mace",
     "fetch:laser-mace-engine": "./scripts/sync-package.sh laser-mace-engine packages/laser-mace-engine",
-    "fetch:laser-mace-testing": "./scripts/sync-package.sh laser-mace-testing packages/laser-mace-testing"
+    "fetch:laser-mace-testing": "./scripts/sync-package.sh laser-mace-testing packages/laser-mace-testing",
+    "build:laser-mace-testing": "npm run build --workspace laser-mace-testing",
+    "start:laser-mace-testing": "npm run start --workspace laser-mace-testing",
+    "dev:laser-mace-testing": "npm run dev --workspace laser-mace-testing",
+    "vercel-build": "npm run build:laser-mace-testing"
   }
 }


### PR DESCRIPTION
## Summary
- add workspace passthrough scripts for the laser-mace-testing app at the repo root
- provide a vercel-build alias so Vercel can target the laser-mace-testing workspace

## Testing
- npm run lint
- npm run build:laser-mace-testing

------
https://chatgpt.com/codex/tasks/task_b_68d763c276448330a76a1c0647e88205